### PR TITLE
Add script to register services in sandboxes only

### DIFF
--- a/register-service-broker-exclude-sandboxes.yml
+++ b/register-service-broker-exclude-sandboxes.yml
@@ -11,7 +11,7 @@ image_resource:
     tag: latest
 
 inputs:
-- name: pipeline-tasks
+  - name: pipeline-tasks
 
 run:
   path: pipeline-tasks/register-service-broker-and-set-plan-visibility.sh

--- a/register-service-broker-only-sandboxes.yml
+++ b/register-service-broker-only-sandboxes.yml
@@ -1,0 +1,19 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: general-task
+    aws_region: us-gov-west-1
+    tag: latest
+
+inputs:
+  - name: pipeline-tasks
+
+run:
+  path: pipeline-tasks/register-service-broker-and-set-plan-visibility.sh
+  args:
+    - -o


### PR DESCRIPTION
## Changes proposed in this pull request:

There are some plans, like the `s3:basic-sandbox` plan, that we only want to be used in sandboxes. In that case, `s3:basic-sandbox` exists as a plan because it allows the bucket contents to be cleared when we periodically wipe sandbox spaces. 

There may be other cases where we want to register services only for the sandboxes in the future, so we need a pipeline task definition for registering brokered services to sandbox orgs only.

- Add `register-service-broker-only-sandboxes.yml` task for registering services in sandboxes only
- Rename `register-service-broker-sandboxes.yml` to `register-service-broker-exclude-sandboxes.yml` to clarify the task's behavior
- Update `set-plan-visibility.sh` to support `-o` flag for enabling services for only sandbox orgs

## security considerations

I don't think there is any security impact of registering services only for sandboxes, it is just a necessary platform constraint
